### PR TITLE
mediastore: support for lower-latency streaming via wishful thinking

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,15 @@ name on mediastore:
 s3-upload-proxy configuration's is defined using the following environment
 variables:
 
-| Variable            | Default value | Required | Description                                                                      |
-| ------------------- | ------------- | -------- | -------------------------------------------------------------------------------- |
-| UPLOAD_DRIVER       | s3            | No       | Upload driver to use (options are "mediastore" or "s3")                          |
-| BUCKET_NAME         |               | Yes      | Name of the S3 bucket or the mediastore container (depends on the upload driver) |
-| HEALTHCHECK_PATH    | /healthcheck  | No       | Path for healthcheck                                                             |
-| HTTP_PORT           | 80            | No       | Port to bind (unsigned int)                                                      |
-| LOG_LEVEL           | debug         | No       | Logging level                                                                    |
-| CACHE_CONTROL_RULES |               | No       | JSON array with cache control rules (see below)                                  |
+| Variable                    | Default value | Required | Description                                                                      |
+| --------------------------- | ------------- | -------- | -------------------------------------------------------------------------------- |
+| UPLOAD_DRIVER               | s3            | No       | Upload driver to use (options are "mediastore" or "s3")                          |
+| BUCKET_NAME                 |               | Yes      | Name of the S3 bucket or the mediastore container (depends on the upload driver) |
+| HEALTHCHECK_PATH            | /healthcheck  | No       | Path for healthcheck                                                             |
+| HTTP_PORT                   | 80            | No       | Port to bind (unsigned int)                                                      |
+| LOG_LEVEL                   | debug         | No       | Logging level                                                                    |
+| CACHE_CONTROL_RULES         |               | No       | JSON array with cache control rules (see below)                                  |
+| MEDIASTORE_CHUNKED_TRANSFER | false         | No       | Whether to enable chunked transfer with MediaStore for lower latency             |
 
 ## Defining cache-control rules
 

--- a/internal/uploader/mediastore/mediastore.go
+++ b/internal/uploader/mediastore/mediastore.go
@@ -10,13 +10,23 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/mediastore"
 	"github.com/aws/aws-sdk-go-v2/service/mediastoredata"
+	"github.com/aws/aws-sdk-go-v2/service/mediastoredata/types"
 	awsint "github.com/fsouza/s3-upload-proxy/internal/aws"
 	"github.com/fsouza/s3-upload-proxy/internal/uploader"
 )
 
+// DriverOptions are the set of options that can change how the mediastore
+// driver behaves.
+type DriverOptions struct {
+	ChunkedTransfer bool
+}
+
 // New returns an uploader that sends objects to Elemental MediaStore.
-func New() (uploader.Uploader, error) {
-	var u msUploader
+func New(options DriverOptions) (uploader.Uploader, error) {
+	u := msUploader{uploadAvailability: types.UploadAvailabilityStandard}
+	if options.ChunkedTransfer {
+		u.uploadAvailability = types.UploadAvailabilityStreaming
+	}
 	sess, err := awsint.Config()
 	if err != nil {
 		return nil, err
@@ -26,8 +36,9 @@ func New() (uploader.Uploader, error) {
 }
 
 type msUploader struct {
-	client     *mediastore.Client
-	containers sync.Map
+	client             *mediastore.Client
+	containers         sync.Map
+	uploadAvailability types.UploadAvailability
 }
 
 func (u *msUploader) Upload(options uploader.Options) error {
@@ -36,10 +47,11 @@ func (u *msUploader) Upload(options uploader.Options) error {
 		return err
 	}
 	input := mediastoredata.PutObjectInput{
-		Path:         aws.String(options.Path),
-		ContentType:  options.ContentType,
-		CacheControl: options.CacheControl,
-		Body:         options.Body,
+		Path:               aws.String(options.Path),
+		ContentType:        options.ContentType,
+		CacheControl:       options.CacheControl,
+		Body:               options.Body,
+		UploadAvailability: u.uploadAvailability,
 	}
 	_, err = client.PutObject(options.Context, &input)
 	return err


### PR DESCRIPTION
Need aws/aws-sdk-go-v2#1094 to remove the wishful thinking part :)