### PR TITLE
github/worfklows/main: run checkout before setup-go

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,12 +13,11 @@ jobs:
     name: tests
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3.5.2
+
       - uses: actions/setup-go@v4.0.0
-        id: go
         with:
           go-version: "1.20"
-
-      - uses: actions/checkout@v3.5.2
 
       - name: run-tests
         run: go test -race -vet all ./...
@@ -36,6 +35,8 @@ jobs:
     name: staticcheck
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3.5.2
+
       - uses: actions/setup-go@v4.0.0
         id: setup-go
         with:
@@ -55,8 +56,6 @@ jobs:
         with:
           path: ~/.cache/staticcheck
           key: "${{ steps.get-staticcheck-version.outputs.version }}-${{ steps.setup-go.outputs.go-version }}"
-
-      - uses: actions/checkout@v3.5.2
 
       - name: run staticcheck
         run: |


### PR DESCRIPTION
This should fix caching for `actions/setup-go` and all the warnings in CI.